### PR TITLE
Add a link to pre-build binaries for Mac and Windows

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,9 @@ SourceArt/**/*.png
 SourceArt/**/*.tga
 
 # Binary Files
+Binaries/*
 Plugins/*/Binaries/*
+Plugins/**/Binaries/*
 !Binaries/*
 !Binaries/*/*.dll
 
@@ -70,6 +72,10 @@ Saved/*
 # Compiled source files for the engine to use
 Intermediate/*
 Plugins/*/Intermediate/*
+Plugins/**/Intermediate/*
 
 # Cache files for the editor to use
 DerivedDataCache/*
+
+# MacOS finder metadata files
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -20,8 +20,14 @@ Watch the Gameplay Video [here](https://www.youtube.com/watch?v=Dbrez3j3f40)
 ![Activate the plugin](https://i.imgur.com/NfcOLTk.png)
 
 - Restart the Editor, and the Game mode should be activated automatically
-## Roadmap
+
+# Roadmap
 
 There are some missing features that are not implemented yet.
 - AI Capture the flag logic
 - Players carrying the flag should drop the flag in place after dying
+
+
+# Pre-made Builds
+Here's a link to Mac and Windows builds of Lyra with this plugin/feature included, in case you want to try it without having to download Unreal Engine 5 and the Lyra Game sample project.  These builds are around 600Mb, Unreal Engine 5 + Lyra Game source is around 45Gb.
+  - https://drive.google.com/drive/folders/1cviBFtycP3VAoK5eheK04D54NZTmR-Cm?usp=sharing

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Watch the Gameplay Video [here](https://www.youtube.com/watch?v=Dbrez3j3f40)
 
 - Restart the Editor, and the Game mode should be activated automatically
 
-# Pre-made Builds
+# Pre-made Playable Builds
 Here's a link to Mac and Windows builds of the Lyra Starter Project with this plugin/feature included, incase you want to try playing this game/feature without having to download Unreal Engine 5 and the Lyra Starter Game package.  These builds are around 600Mb, Unreal Engine 5 + Lyra Game source is around 45Gb.
   - https://drive.google.com/drive/folders/1cviBFtycP3VAoK5eheK04D54NZTmR-Cm?usp=sharing
 ![image](https://user-images.githubusercontent.com/3343322/194797345-6e13f0d5-001e-4401-bc87-da8edef240cf.png)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Unreal Engine 5 comes with a new feature called [Game Features Plugins](https://docs.unrealengine.com/5.0/en-US/game-features-and-modular-gameplay/) allowing for modular and standalone game content. The [Lyra Starter game](https://www.unrealengine.com/marketplace/en-US/product/lyra) already uses this feature extensively to create modular game modes such as the Control point and the Team deathmatch.
 
-This plugin is a standalone Capture the Flag game mode that can be added to the Lyra Start Game without any changes to the core content of the project.
+This plugin is a standalone Capture the Flag game mode that can be added to the Lyra Starter Game without any changes to the core content of the project.
 
 Watch the Gameplay Video [here](https://www.youtube.com/watch?v=Dbrez3j3f40) 
 
@@ -21,13 +21,13 @@ Watch the Gameplay Video [here](https://www.youtube.com/watch?v=Dbrez3j3f40)
 
 - Restart the Editor, and the Game mode should be activated automatically
 
+# Pre-made Builds
+Here's a link to Mac and Windows builds of the Lyra Starter Project with this plugin/feature included.  These builds are around 600Mb, Unreal Engine 5 + Lyra Game source is around 45Gb.
+  - https://drive.google.com/drive/folders/1cviBFtycP3VAoK5eheK04D54NZTmR-Cm?usp=sharing
+![image](https://user-images.githubusercontent.com/3343322/194797345-6e13f0d5-001e-4401-bc87-da8edef240cf.png)
+
 # Roadmap
 
 There are some missing features that are not implemented yet.
 - AI Capture the flag logic
 - Players carrying the flag should drop the flag in place after dying
-
-
-# Pre-made Builds
-Here's a link to Mac and Windows builds of Lyra with this plugin/feature included, in case you want to try it without having to download Unreal Engine 5 and the Lyra Game sample project.  These builds are around 600Mb, Unreal Engine 5 + Lyra Game source is around 45Gb.
-  - https://drive.google.com/drive/folders/1cviBFtycP3VAoK5eheK04D54NZTmR-Cm?usp=sharing

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Watch the Gameplay Video [here](https://www.youtube.com/watch?v=Dbrez3j3f40)
 - Restart the Editor, and the Game mode should be activated automatically
 
 # Pre-made Builds
-Here's a link to Mac and Windows builds of the Lyra Starter Project with this plugin/feature included.  These builds are around 600Mb, Unreal Engine 5 + Lyra Game source is around 45Gb.
+Here's a link to Mac and Windows builds of the Lyra Starter Project with this plugin/feature included, incase you want to try playing this game/feature without having to download Unreal Engine 5 and the Lyra Starter Game package.  These builds are around 600Mb, Unreal Engine 5 + Lyra Game source is around 45Gb.
   - https://drive.google.com/drive/folders/1cviBFtycP3VAoK5eheK04D54NZTmR-Cm?usp=sharing
 ![image](https://user-images.githubusercontent.com/3343322/194797345-6e13f0d5-001e-4401-bc87-da8edef240cf.png)
 


### PR DESCRIPTION
This PR includes:
- A link in the Readme to pre-build binaries for Mac and Windows
- Some updates to the .gitignore for working on a Mac
- A new .github/ISSUE_TEMPLATE/feature_request.md, for use with Github Projects